### PR TITLE
Compatibility with older C standards

### DIFF
--- a/ext/buffer.c
+++ b/ext/buffer.c
@@ -217,7 +217,8 @@ bufsize_t cmark_strbuf_strrchr(const cmark_strbuf *buf, int c, bufsize_t pos) {
   if (pos >= buf->size)
     pos = buf->size - 1;
 
-  for (bufsize_t i = pos; i >= 0; i--) {
+  bufsize_t i;
+  for (i = pos; i >= 0; i--) {
     if (buf->ptr[i] == (unsigned char)c)
       return i;
   }


### PR DESCRIPTION
I can't find any compiler standard explicitly specified in this project. Some
versions of GCC defaults to older standards of C if no standard is specicied
with "-std=[standard]". For example "-std=c11" to set C11 standard.

Since there is only one place in the code where newer C-style is being used
it's might be easier to just change that place (ext:buffer.c:220).
